### PR TITLE
Fix TestPyPI publish: skip-existing for duplicate version uploads

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -54,6 +54,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   publish-pypi:
     name: Publish to PyPI


### PR DESCRIPTION
Version 0.0.1 already exists on TestPyPI from the initial push. Subsequent pushes to main that touch sdk/python/ trigger the publish workflow, which fails with 400 Bad Request. skip-existing: true handles this gracefully.